### PR TITLE
[fix] NameError: uninitialized constant RedmineExtensions::Migration

### DIFF
--- a/lib/redmine_extensions.rb
+++ b/lib/redmine_extensions.rb
@@ -1,2 +1,3 @@
 require_relative "./redmine_extensions/engine"
 require_relative './redmine_extensions/core_ext'
+require_relative './redmine_extensions/migration'


### PR DESCRIPTION
I got following errors while trying to install a plugin requiring redmine_extensions:
```
$ RAILS_ENV=production bundle exec rake db:migrate
rake aborted!
NameError: uninitialized constant RedmineExtensions::Migration
/usr/share/rvm/gems/ruby-2.6.6/gems/redmine_extensions-0.3.9/db/migrate/20150705172511_create_easy_settings.rb:1:in `<top (required)>'
/usr/share/rvm/gems/ruby-2.6.6/gems/polyglot-0.3.5/lib/polyglot.rb:65:in `require'
/usr/share/rvm/gems/ruby-2.6.6/gems/polyglot-0.3.5/lib/polyglot.rb:65:in `require'
/usr/share/rvm/gems/ruby-2.6.6/gems/activesupport-5.2.4.5/lib/active_support/dependencies.rb:291:in `block in require'
/usr/share/rvm/gems/ruby-2.6.6/gems/activesupport-5.2.4.5/lib/active_support/dependencies.rb:257:in `load_dependency'
/usr/share/rvm/gems/ruby-2.6.6/gems/activesupport-5.2.4.5/lib/active_support/dependencies.rb:291:in `require'
/usr/share/rvm/gems/ruby-2.6.6/gems/activerecord-5.2.4.5/lib/active_record/migration.rb:986:in `load_migration'
/usr/share/rvm/gems/ruby-2.6.6/gems/activerecord-5.2.4.5/lib/active_record/migration.rb:982:in `migration'
/usr/share/rvm/gems/ruby-2.6.6/gems/activerecord-5.2.4.5/lib/active_record/migration.rb:977:in `disable_ddl_transaction'
/usr/share/rvm/gems/ruby-2.6.6/gems/activerecord-5.2.4.5/lib/active_record/migration.rb:1350:in `use_transaction?'
/usr/share/rvm/gems/ruby-2.6.6/gems/activerecord-5.2.4.5/lib/active_record/migration.rb:1297:in `rescue in execute_migration_in_transaction'
/usr/share/rvm/gems/ruby-2.6.6/gems/activerecord-5.2.4.5/lib/active_record/migration.rb:1285:in `execute_migration_in_transaction'
/usr/share/rvm/gems/ruby-2.6.6/gems/activerecord-5.2.4.5/lib/active_record/migration.rb:1263:in `block in migrate_without_lock'
/usr/share/rvm/gems/ruby-2.6.6/gems/activerecord-5.2.4.5/lib/active_record/migration.rb:1262:in `each'
/usr/share/rvm/gems/ruby-2.6.6/gems/activerecord-5.2.4.5/lib/active_record/migration.rb:1262:in `migrate_without_lock'
/usr/share/rvm/gems/ruby-2.6.6/gems/activerecord-5.2.4.5/lib/active_record/migration.rb:1210:in `block in migrate'
/usr/share/rvm/gems/ruby-2.6.6/gems/activerecord-5.2.4.5/lib/active_record/migration.rb:1363:in `with_advisory_lock'
/usr/share/rvm/gems/ruby-2.6.6/gems/activerecord-5.2.4.5/lib/active_record/migration.rb:1210:in `migrate'
/usr/share/rvm/gems/ruby-2.6.6/gems/activerecord-5.2.4.5/lib/active_record/migration.rb:1036:in `up'
/usr/share/rvm/gems/ruby-2.6.6/gems/activerecord-5.2.4.5/lib/active_record/migration.rb:1011:in `migrate'
/usr/share/rvm/gems/ruby-2.6.6/gems/activerecord-5.2.4.5/lib/active_record/tasks/database_tasks.rb:172:in `migrate'
/usr/share/rvm/gems/ruby-2.6.6/gems/activerecord-5.2.4.5/lib/active_record/railties/databases.rake:60:in `block (2 levels) in <top (required)>'
/usr/share/rvm/gems/ruby-2.6.6/gems/rake-13.0.6/exe/rake:27:in `<top (required)>'
/usr/share/rvm/gems/ruby-2.6.6/bin/ruby_executable_hooks:22:in `eval'
/usr/share/rvm/gems/ruby-2.6.6/bin/ruby_executable_hooks:22:in `<main>'

Caused by:
NameError: uninitialized constant RedmineExtensions::Migration
/usr/share/rvm/gems/ruby-2.6.6/gems/redmine_extensions-0.3.9/db/migrate/20150705172511_create_easy_settings.rb:1:in `<top (required)>'
/usr/share/rvm/gems/ruby-2.6.6/gems/polyglot-0.3.5/lib/polyglot.rb:65:in `require'
/usr/share/rvm/gems/ruby-2.6.6/gems/polyglot-0.3.5/lib/polyglot.rb:65:in `require'
/usr/share/rvm/gems/ruby-2.6.6/gems/activesupport-5.2.4.5/lib/active_support/dependencies.rb:291:in `block in require'
/usr/share/rvm/gems/ruby-2.6.6/gems/activesupport-5.2.4.5/lib/active_support/dependencies.rb:257:in `load_dependency'
/usr/share/rvm/gems/ruby-2.6.6/gems/activesupport-5.2.4.5/lib/active_support/dependencies.rb:291:in `require'
/usr/share/rvm/gems/ruby-2.6.6/gems/activerecord-5.2.4.5/lib/active_record/migration.rb:986:in `load_migration'
/usr/share/rvm/gems/ruby-2.6.6/gems/activerecord-5.2.4.5/lib/active_record/migration.rb:982:in `migration'
/usr/share/rvm/gems/ruby-2.6.6/gems/activerecord-5.2.4.5/lib/active_record/migration.rb:977:in `disable_ddl_transaction'
/usr/share/rvm/gems/ruby-2.6.6/gems/activerecord-5.2.4.5/lib/active_record/migration.rb:1350:in `use_transaction?'
/usr/share/rvm/gems/ruby-2.6.6/gems/activerecord-5.2.4.5/lib/active_record/migration.rb:1342:in `ddl_transaction'
/usr/share/rvm/gems/ruby-2.6.6/gems/activerecord-5.2.4.5/lib/active_record/migration.rb:1291:in `execute_migration_in_transaction'
/usr/share/rvm/gems/ruby-2.6.6/gems/activerecord-5.2.4.5/lib/active_record/migration.rb:1263:in `block in migrate_without_lock'
/usr/share/rvm/gems/ruby-2.6.6/gems/activerecord-5.2.4.5/lib/active_record/migration.rb:1262:in `each'
/usr/share/rvm/gems/ruby-2.6.6/gems/activerecord-5.2.4.5/lib/active_record/migration.rb:1262:in `migrate_without_lock'
/usr/share/rvm/gems/ruby-2.6.6/gems/activerecord-5.2.4.5/lib/active_record/migration.rb:1210:in `block in migrate'
/usr/share/rvm/gems/ruby-2.6.6/gems/activerecord-5.2.4.5/lib/active_record/migration.rb:1363:in `with_advisory_lock'
/usr/share/rvm/gems/ruby-2.6.6/gems/activerecord-5.2.4.5/lib/active_record/migration.rb:1210:in `migrate'
/usr/share/rvm/gems/ruby-2.6.6/gems/activerecord-5.2.4.5/lib/active_record/migration.rb:1036:in `up'
/usr/share/rvm/gems/ruby-2.6.6/gems/activerecord-5.2.4.5/lib/active_record/migration.rb:1011:in `migrate'
/usr/share/rvm/gems/ruby-2.6.6/gems/activerecord-5.2.4.5/lib/active_record/tasks/database_tasks.rb:172:in `migrate'
/usr/share/rvm/gems/ruby-2.6.6/gems/activerecord-5.2.4.5/lib/active_record/railties/databases.rake:60:in `block (2 levels) in <top (required)>'
/usr/share/rvm/gems/ruby-2.6.6/gems/rake-13.0.6/exe/rake:27:in `<top (required)>'
/usr/share/rvm/gems/ruby-2.6.6/bin/ruby_executable_hooks:22:in `eval'
/usr/share/rvm/gems/ruby-2.6.6/bin/ruby_executable_hooks:22:in `<main>'
Tasks: TOP => db:migrate
(See full trace by running task with --trace)
```

I found that `RedmineExtensions::Migration` is actually defined in `lib/redmine_extensions/migration.rb` but it's not included in `lib/redmine_extensions.rb`, after including it, I can install my plugin successfully.
